### PR TITLE
Update processSeason to check for empty sessions array

### DIFF
--- a/league_db/league.go
+++ b/league_db/league.go
@@ -113,6 +113,10 @@ func (l *League) processSeason(seasonId int) {
 		delete(s, "weather")
 	}
 
+	if len(rawSessions["sessions"].([]interface{})) == 0 {
+		return
+	}
+
 	l.WriteParquet(rawSessions["sessions"], fmt.Sprintf("sessions-%d", seasonId))
 
 	for _, s := range rawSessions["sessions"].([]interface{}) {


### PR DESCRIPTION
Updates processSeason to handle seasons with no sessions.

```
INFO[2024-12-07T16:28:03-05:00] httpClient.Get                                retries=5 url="https://members-ng.iracing.com/data/league/season_sessions?league_id=8093&season_id=113890"

2024/12/07 17:19:24 IO Error: Failed to read file "data/sessions-113890.parquet": schema mismatch in glob: column "cars" was read from the original file "data/sessions-101230.parquet", but could not be found in file "data/sessions-113890.parquet".
Candidate names: json
If you are trying to read files with different schemas, try setting union_by_name=True
panic: IO Error: Failed to read file "data/sessions-113890.parquet": schema mismatch in glob: column "cars" was read from the original file "data/sessions-101230.parquet", but could not be found in file "data/sessions-113890.parquet".
	Candidate names: json
	If you are trying to read files with different schemas, try setting union_by_name=True

goroutine 1 [running]:
log.Panic({0xc00003bdd8?, 0x102816600?, 0x102b23060?})
	/Users/user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.darwin-amd64/src/log/log.go:432 +0x5a
main.(*League).MergeParquet(0xc00003bf08, {0x10231b4e5, 0xa}, {0x10231ac16, 0x8})
	/Users/user/develop/iracing/irdata_tools/league_db/writer.go:75 +0x1d9
main.(*League).processLeague(0xc00003bf08)
	/Users/user/develop/iracing/irdata_tools/league_db/league.go:89 +0x557
main.main()
	/Users/user/develop/iracing/irdata_tools/league_db/main.go:58 +0x21c
```